### PR TITLE
Fix reverse initialization of vertical segments causing teleports

### DIFF
--- a/gym_graph_traffic/envs/graph_traffic.py
+++ b/gym_graph_traffic/envs/graph_traffic.py
@@ -60,7 +60,7 @@ class GraphTrafficEnv(gym.Env):
                               enumerate(params.intersections)]
 
         i = 0
-        # (100, "r", 0, "l", 1) is a segment of length 100 going
+        # (100, 0, "r", 1, "l") is a segment of length 100 going
         #                       from right side of intersection 0
         #                       to left side of intersection 1
         for (length, from_idx, from_side, to_idx, to_side) in params.segments:

--- a/util/grid.py
+++ b/util/grid.py
@@ -10,18 +10,18 @@ def make_grid(grid_cols, grid_rows, scale_factor, segment_len=100, margin=20):
                                y * (INTERSECTION_SIZE + segment_len) + margin)
                               for y in range(grid_rows) for x in range(grid_cols)],
             "segments":
-            # l → r
+                # l → r
                 [(segment_len, x, "r", (x + 1) if (x + 1) % grid_cols != 0 else (x + 1) - grid_cols, "l")
                  for x in range(grid_rows * grid_cols)]
                 +  # r ← l
                 [(segment_len, (x + 1) if (x + 1) % grid_cols != 0 else (x + 1) - grid_cols, "l", x, "r")
                  for x in range(grid_rows * grid_cols)]
-                +  # u ↓ d
-                [(segment_len, x, "u", (x + grid_cols) if (x + grid_cols) < (grid_cols * grid_rows - 1) else (
-                        (x + grid_cols) % (grid_cols * grid_rows)), "d") for x in range(grid_rows * grid_cols)]
                 +  # d ↑ u
+                [(segment_len, x, "d", (x + grid_cols) if (x + grid_cols) < (grid_cols * grid_rows - 1) else (
+                        (x + grid_cols) % (grid_cols * grid_rows)), "u") for x in range(grid_rows * grid_cols)]
+                +  # u ↓ d
                 [(segment_len, (x + grid_cols) if (x + grid_cols) < (grid_cols * grid_rows - 1) else (
-                        (x + grid_cols) % (grid_cols * grid_rows)), "d", x, "u") for x in range(grid_rows * grid_cols)]
+                        (x + grid_cols) % (grid_cols * grid_rows)), "u", x, "d") for x in range(grid_rows * grid_cols)]
             }
 
 


### PR DESCRIPTION
The bug in generating segments not according to the definition from graph_traffic.py caused discrepancy between actual logical topology and visualization and existence of artifacts such us upward going edge from bottom to top intersection. This caused the effect of "teleportations" between intersections on presets with non-trivial verticality.